### PR TITLE
Add some common string constants

### DIFF
--- a/alphabets.go
+++ b/alphabets.go
@@ -1,0 +1,25 @@
+package xstrings
+
+const (
+	// ASCIILowercase stores the ASCII lowercase latin alphabet.
+	ASCIILowercase = "abcdefghijklmnopqrstuvwxyz"
+
+	// ASCIIUppercase stores the ASCII uppercase latin alphabet.
+	ASCIIUppercase = "ABCDEFGHIJKLMNOPQRSTUVWXYZ"
+
+	// Digits stores the set of ASCII digits.
+	// Do not use this string as a filter for runes,
+	// consider using the unicode.IsDigit function instead.
+	Digits = "0123456789"
+
+	// HexDigits stores the set of symbols which can represent a hex value.
+	HexDigits = "0123456789abcdefABCDEF"
+
+	// OctDigits stores the set of symbols which can represent an octal value.
+	OctDigits = "01234567"
+
+	// Punctuation stores the set of ASCII punctuation characters.
+	// Do not use this string as a filter for runes,
+	// consider using the unicode.IsPunct function instead.
+	Punctuation = "#$%&'()*+,-./:;<=>?@[\\]^_`{|}~"
+)


### PR DESCRIPTION
Despite the fact that the `unicode` package allows you to get almost all unicode ranges, it can be somewhat cumbersome to use. In addition, its use forces the inclusion of a large symbol table in the executable file. At the same time, there is a set of characters that are most often found in text data formats. I suggest adding constant strings with these characters, similar to the way it is done in the [python standard library](https://docs.python.org/3.8/library/string.html#string-constants).