### PR TITLE
fix snakecase's behaviour on already-snakecased numbers

### DIFF
--- a/convert.go
+++ b/convert.go
@@ -130,7 +130,7 @@ func camelCaseToLowerCase(str string, connector rune) string {
 				wt, word, remaining = nextWord(remaining)
 			}
 
-			if wt != invalidWord && wt != punctWord {
+			if wt != invalidWord && wt != punctWord && wt != connectorWord {
 				buf.WriteRune(connector)
 			}
 

--- a/convert_test.go
+++ b/convert_test.go
@@ -45,6 +45,8 @@ func TestToSnakeCaseAndToKebabCase(t *testing.T) {
 		"": "",
 		"Abc\uFFFDE\uFFFDf\uFFFDd\uFFFD2\uFFFD00z\uFFFDZZ\uFFFDZZ": "abc_\uFFFDe\uFFFDf\uFFFDd_\uFFFD2\uFFFD00z_\uFFFDzz\uFFFDzz",
 		"\uFFFD\uFFFD\uFFFD\uFFFD\uFFFD":                           "\uFFFD\uFFFD\uFFFD\uFFFD\uFFFD",
+
+		"abc_123_def": "abc_123_def",
 	}
 
 	runTestCases(t, ToSnakeCase, cases)


### PR DESCRIPTION
Hey, found an interesting one via this project's indirect use in Helm.

Running ToSnakeCase on `ABC_123_DEF` adds an extra underscore, yielding `ABC_123__DEF`. Expected behaviour would be to return the input unchanged.

This PR adds a test and fix for this case.

Thanks for your work on this!

Jarrad