### PR TITLE
ToCamelCase preserves cases

### DIFF
--- a/convert.go
+++ b/convert.go
@@ -12,11 +12,12 @@ import (
 // ToCamelCase is to convert words separated by space, underscore and hyphen to camel case.
 //
 // Some samples.
-//     "some_words"      => "SomeWords"
-//     "http_server"     => "HttpServer"
-//     "no_https"        => "NoHttps"
-//     "_complex__case_" => "_Complex_Case_"
-//     "some words"      => "SomeWords"
+//
+//	"some_words"      => "SomeWords"
+//	"http_server"     => "HttpServer"
+//	"no_https"        => "NoHttps"
+//	"_complex__case_" => "_Complex_Case_"
+//	"some words"      => "SomeWords"
 func ToCamelCase(str string) string {
 	if len(str) == 0 {
 		return ""
@@ -61,7 +62,6 @@ func ToCamelCase(str string) string {
 		if isConnector(r1) {
 			r0 = unicode.ToUpper(r0)
 		} else {
-			r0 = unicode.ToLower(r0)
 			buf.WriteRune(r1)
 		}
 	}
@@ -74,16 +74,17 @@ func ToCamelCase(str string) string {
 // snake case format.
 //
 // Some samples.
-//     "FirstName"    => "first_name"
-//     "HTTPServer"   => "http_server"
-//     "NoHTTPS"      => "no_https"
-//     "GO_PATH"      => "go_path"
-//     "GO PATH"      => "go_path"  // space is converted to underscore.
-//     "GO-PATH"      => "go_path"  // hyphen is converted to underscore.
-//     "http2xx"      => "http_2xx" // insert an underscore before a number and after an alphabet.
-//     "HTTP20xOK"    => "http_20x_ok"
-//     "Duration2m3s" => "duration_2m3s"
-//     "Bld4Floor3rd" => "bld4_floor_3rd"
+//
+//	"FirstName"    => "first_name"
+//	"HTTPServer"   => "http_server"
+//	"NoHTTPS"      => "no_https"
+//	"GO_PATH"      => "go_path"
+//	"GO PATH"      => "go_path"  // space is converted to underscore.
+//	"GO-PATH"      => "go_path"  // hyphen is converted to underscore.
+//	"http2xx"      => "http_2xx" // insert an underscore before a number and after an alphabet.
+//	"HTTP20xOK"    => "http_20x_ok"
+//	"Duration2m3s" => "duration_2m3s"
+//	"Bld4Floor3rd" => "bld4_floor_3rd"
 func ToSnakeCase(str string) string {
 	return camelCaseToLowerCase(str, '_')
 }
@@ -92,16 +93,17 @@ func ToSnakeCase(str string) string {
 // kebab case format.
 //
 // Some samples.
-//     "FirstName"    => "first-name"
-//     "HTTPServer"   => "http-server"
-//     "NoHTTPS"      => "no-https"
-//     "GO_PATH"      => "go-path"
-//     "GO PATH"      => "go-path"  // space is converted to '-'.
-//     "GO-PATH"      => "go-path"  // hyphen is converted to '-'.
-//     "http2xx"      => "http-2xx" // insert an underscore before a number and after an alphabet.
-//     "HTTP20xOK"    => "http-20x-ok"
-//     "Duration2m3s" => "duration-2m3s"
-//     "Bld4Floor3rd" => "bld4-floor-3rd"
+//
+//	"FirstName"    => "first-name"
+//	"HTTPServer"   => "http-server"
+//	"NoHTTPS"      => "no-https"
+//	"GO_PATH"      => "go-path"
+//	"GO PATH"      => "go-path"  // space is converted to '-'.
+//	"GO-PATH"      => "go-path"  // hyphen is converted to '-'.
+//	"http2xx"      => "http-2xx" // insert an underscore before a number and after an alphabet.
+//	"HTTP20xOK"    => "http-20x-ok"
+//	"Duration2m3s" => "duration-2m3s"
+//	"Bld4Floor3rd" => "bld4-floor-3rd"
 func ToKebabCase(str string) string {
 	return camelCaseToLowerCase(str, '-')
 }
@@ -510,17 +512,18 @@ func ShuffleSource(str string, src rand.Source) string {
 // regardless whether the result is a valid rune or not.
 //
 // Only following characters are alphanumeric.
-//     * a - z
-//     * A - Z
-//     * 0 - 9
+//   - a - z
+//   - A - Z
+//   - 0 - 9
 //
 // Samples (borrowed from ruby's String#succ document):
-//     "abcd"      => "abce"
-//     "THX1138"   => "THX1139"
-//     "<<koala>>" => "<<koalb>>"
-//     "1999zzz"   => "2000aaa"
-//     "ZZZ9999"   => "AAAA0000"
-//     "***"       => "**+"
+//
+//	"abcd"      => "abce"
+//	"THX1138"   => "THX1139"
+//	"<<koala>>" => "<<koalb>>"
+//	"1999zzz"   => "2000aaa"
+//	"ZZZ9999"   => "AAAA0000"
+//	"***"       => "**+"
 func Successor(str string) string {
 	if str == "" {
 		return str

--- a/convert_test.go
+++ b/convert_test.go
@@ -66,12 +66,12 @@ func TestToCamelCase(t *testing.T) {
 		"_complex__case_": "_Complex_Case_",
 		" complex -case ": " Complex Case ",
 		"all":             "All",
-		"GOLANG_IS_GREAT": "GolangIsGreat",
-		"GOLANG":          "Golang",
+		"GOLANG_IS_GREAT": "GOLANGISGREAT",
+		"GOLANG":          "GOLANG",
 		"a":               "A",
 		"好":               "好",
 
-		"FROM CamelCase to snake/kebab-case": "FromCamelcaseToSnake/kebabCase",
+		"FROM CamelCase to snake/kebab-case": "FROMCamelCaseToSnake/kebabCase",
 
 		"": "",
 	})

--- a/format.go
+++ b/format.go
@@ -17,9 +17,10 @@ import (
 // If tabSize <= 0, ExpandTabs panics with error.
 //
 // Samples:
-//     ExpandTabs("a\tbc\tdef\tghij\tk", 4) => "a   bc  def ghij    k"
-//     ExpandTabs("abcdefg\thij\nk\tl", 4)  => "abcdefg hij\nk   l"
-//     ExpandTabs("z中\t文\tw", 4)           => "z中 文  w"
+//
+//	ExpandTabs("a\tbc\tdef\tghij\tk", 4) => "a   bc  def ghij    k"
+//	ExpandTabs("abcdefg\thij\nk\tl", 4)  => "abcdefg hij\nk   l"
+//	ExpandTabs("z中\t文\tw", 4)           => "z中 文  w"
 func ExpandTabs(str string, tabSize int) string {
 	if tabSize <= 0 {
 		panic("tab size must be positive")
@@ -74,9 +75,10 @@ func ExpandTabs(str string, tabSize int) string {
 // If pad is an empty string, str will be returned.
 //
 // Samples:
-//     LeftJustify("hello", 4, " ")    => "hello"
-//     LeftJustify("hello", 10, " ")   => "hello     "
-//     LeftJustify("hello", 10, "123") => "hello12312"
+//
+//	LeftJustify("hello", 4, " ")    => "hello"
+//	LeftJustify("hello", 10, " ")   => "hello     "
+//	LeftJustify("hello", 10, "123") => "hello12312"
 func LeftJustify(str string, length int, pad string) string {
 	l := Len(str)
 
@@ -100,9 +102,10 @@ func LeftJustify(str string, length int, pad string) string {
 // If pad is an empty string, str will be returned.
 //
 // Samples:
-//     RightJustify("hello", 4, " ")    => "hello"
-//     RightJustify("hello", 10, " ")   => "     hello"
-//     RightJustify("hello", 10, "123") => "12312hello"
+//
+//	RightJustify("hello", 4, " ")    => "hello"
+//	RightJustify("hello", 10, " ")   => "     hello"
+//	RightJustify("hello", 10, "123") => "12312hello"
 func RightJustify(str string, length int, pad string) string {
 	l := Len(str)
 
@@ -126,9 +129,10 @@ func RightJustify(str string, length int, pad string) string {
 // If pad is an empty string, str will be returned.
 //
 // Samples:
-//     Center("hello", 4, " ")    => "hello"
-//     Center("hello", 10, " ")   => "  hello   "
-//     Center("hello", 10, "123") => "12hello123"
+//
+//	Center("hello", 4, " ")    => "hello"
+//	Center("hello", 10, " ")   => "  hello   "
+//	Center("hello", 10, "123") => "12hello123"
 func Center(str string, length int, pad string) string {
 	l := Len(str)
 

--- a/manipulate.go
+++ b/manipulate.go
@@ -79,10 +79,12 @@ func Slice(str string, start, end int) string {
 // The return value is a slice of strings with head, match and tail.
 //
 // If str contains sep, for example "hello" and "l", Partition returns
-//     "he", "l", "lo"
+//
+//	"he", "l", "lo"
 //
 // If str doesn't contain sep, for example "hello" and "x", Partition returns
-//     "hello", "", ""
+//
+//	"hello", "", ""
 func Partition(str, sep string) (head, match, tail string) {
 	index := strings.Index(str, sep)
 
@@ -101,10 +103,12 @@ func Partition(str, sep string) (head, match, tail string) {
 // The return value is a slice of strings with head, match and tail.
 //
 // If str contains sep, for example "hello" and "l", LastPartition returns
-//     "hel", "l", "o"
+//
+//	"hel", "l", "o"
 //
 // If str doesn't contain sep, for example "hello" and "x", LastPartition returns
-//     "", "", "hello"
+//
+//	"", "", "hello"
 func LastPartition(str, sep string) (head, match, tail string) {
 	index := strings.LastIndex(str, sep)
 

--- a/stringbuilder.go
+++ b/stringbuilder.go
@@ -1,4 +1,5 @@
-//+build go1.10
+//go:build go1.10
+// +build go1.10
 
 package xstrings
 

--- a/stringbuilder_go110.go
+++ b/stringbuilder_go110.go
@@ -1,4 +1,5 @@
-//+build !go1.10
+//go:build !go1.10
+// +build !go1.10
 
 package xstrings
 

--- a/translate.go
+++ b/translate.go
@@ -416,14 +416,16 @@ func (tr *Translator) HasPattern() bool {
 //
 // From and to are patterns representing a set of characters. Pattern is defined as following.
 //
-//     * Special characters
-//       * '-' means a range of runes, e.g.
-//         * "a-z" means all characters from 'a' to 'z' inclusive;
-//         * "z-a" means all characters from 'z' to 'a' inclusive.
-//       * '^' as first character means a set of all runes excepted listed, e.g.
-//         * "^a-z" means all characters except 'a' to 'z' inclusive.
-//       * '\' escapes special characters.
-//     * Normal character represents itself, e.g. "abc" is a set including 'a', 'b' and 'c'.
+// Special characters:
+//
+//  1. '-' means a range of runes, e.g.
+//     "a-z" means all characters from 'a' to 'z' inclusive;
+//     "z-a" means all characters from 'z' to 'a' inclusive.
+//  2. '^' as first character means a set of all runes excepted listed, e.g.
+//     "^a-z" means all characters except 'a' to 'z' inclusive.
+//  3. '\' escapes special characters.
+//
+// Normal character represents itself, e.g. "abc" is a set including 'a', 'b' and 'c'.
 //
 // Translate will try to find a 1:1 mapping from from to to.
 // If to is smaller than from, last rune in to will be used to map "out of range" characters in from.
@@ -433,12 +435,13 @@ func (tr *Translator) HasPattern() bool {
 // If the to pattern is an empty string, Translate works exactly the same as Delete.
 //
 // Samples:
-//     Translate("hello", "aeiou", "12345")    => "h2ll4"
-//     Translate("hello", "a-z", "A-Z")        => "HELLO"
-//     Translate("hello", "z-a", "a-z")        => "svool"
-//     Translate("hello", "aeiou", "*")        => "h*ll*"
-//     Translate("hello", "^l", "*")           => "**ll*"
-//     Translate("hello ^ world", `\^lo`, "*") => "he*** * w*r*d"
+//
+//	Translate("hello", "aeiou", "12345")    => "h2ll4"
+//	Translate("hello", "a-z", "A-Z")        => "HELLO"
+//	Translate("hello", "z-a", "a-z")        => "svool"
+//	Translate("hello", "aeiou", "*")        => "h*ll*"
+//	Translate("hello", "^l", "*")           => "**ll*"
+//	Translate("hello ^ world", `\^lo`, "*") => "he*** * w*r*d"
 func Translate(str, from, to string) string {
 	tr := NewTranslator(from, to)
 	return tr.Translate(str)
@@ -448,9 +451,10 @@ func Translate(str, from, to string) string {
 // Pattern is defined in Translate function.
 //
 // Samples:
-//     Delete("hello", "aeiou") => "hll"
-//     Delete("hello", "a-k")   => "llo"
-//     Delete("hello", "^a-k")  => "he"
+//
+//	Delete("hello", "aeiou") => "hll"
+//	Delete("hello", "a-k")   => "llo"
+//	Delete("hello", "^a-k")  => "he"
 func Delete(str, pattern string) string {
 	tr := NewTranslator(pattern, "")
 	return tr.Translate(str)
@@ -460,9 +464,10 @@ func Delete(str, pattern string) string {
 // Pattern is defined in Translate function.
 //
 // Samples:
-//     Count("hello", "aeiou") => 3
-//     Count("hello", "a-k")   => 3
-//     Count("hello", "^a-k")  => 2
+//
+//	Count("hello", "aeiou") => 3
+//	Count("hello", "a-k")   => 3
+//	Count("hello", "^a-k")  => 2
 func Count(str, pattern string) int {
 	if pattern == "" || str == "" {
 		return 0
@@ -491,9 +496,10 @@ func Count(str, pattern string) int {
 // If pattern is not empty, only runes matching the pattern will be squeezed.
 //
 // Samples:
-//     Squeeze("hello", "")             => "helo"
-//     Squeeze("hello", "m-z")          => "hello"
-//     Squeeze("hello   world", " ")    => "hello world"
+//
+//	Squeeze("hello", "")             => "helo"
+//	Squeeze("hello", "m-z")          => "hello"
+//	Squeeze("hello   world", " ")    => "hello world"
 func Squeeze(str, pattern string) string {
 	var last, r rune
 	var size int


### PR DESCRIPTION
Per request in #54, `ToCamelCase` preserves original case, e.g. `ToCamelCase("toCamelCase") == "ToCamelCase"`.